### PR TITLE
Identify as Fabric3 with -V

### DIFF
--- a/fabric/main.py
+++ b/fabric/main.py
@@ -639,7 +639,7 @@ def main(fabfile_locations=None):
 
         # Handle version number option
         if options.show_version:
-            print("Fabric %s" % state.env.version)
+            print("Fabric3 %s" % state.env.version)
             print("Paramiko %s" % ssh.__version__)
             sys.exit(0)
 


### PR DESCRIPTION
I was slightly confused when trying to check what was installed with `fab -V` to make sure that I was using the functional fork. Minor tweak to help me and hopefully others.