### PR TITLE
Switch to Python 2+3 Rudolf

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 nose
 # Rudolf adds color to the output of 'fab test'. This is a custom fork
 # addressing Python 2.7 and Nose's 'skip' plugin compatibility issues.
--e git+https://github.com/bitprophet/rudolf#egg=rudolf
+-e git+https://github.com/iknite/rudolf#egg=rudolf
 # Mocking library
 Fudge<1.0
 # Documentation generation


### PR DESCRIPTION
Makes 'nosetests --with-color tests/' work under Python 2+3.

Fixes RuntimeWarning when running 'nosetests tests/' under Python 3:
/Users/pzrq/.virtualenvs/fabric343/lib/python3.4/site-packages/nose/plugins/manager.py:395: RuntimeWarning: Unable to load plugin color = rudolf:ColorOutputPlugin: invalid syntax (rudolf.py, line 787)

Seems to make 'nosetests tests/' about 50% slower for unknown reasons, but --with-color or 'fab test' seem far more useful to a developer in this context so it's a good trade off.