### PR TITLE
Fix UnicodeDecodeError when installing Django on a remote server

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 nose
 # Rudolf adds color to the output of 'fab test'. This is a custom fork
 # addressing Python 2.7 and Nose's 'skip' plugin compatibility issues.
--e git+https://github.com/bitprophet/rudolf#egg=rudolf
+-e git+https://github.com/iknite/rudolf#egg=rudolf
 # Mocking library
 Fudge<1.0
 # Documentation generation

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,9 +1,14 @@
+# -*- coding: utf-8 -*-
 from __future__ import with_statement
+
+import sys
+from io import BytesIO
 
 from nose.tools import eq_
 
 from fabric.io import OutputLooper
-from fabric.context_managers import settings
+from fabric.context_managers import hide, settings
+from utils import mock_streams
 
 
 def test_request_prompts():
@@ -26,3 +31,27 @@ def test_request_prompts():
     eq_(run("this is a prompt for prompt2", prompts), ("prompt2", "response2"))
     eq_(run("this is a prompt for promptx:", prompts), (None, None))
     eq_(run("prompt for promp", prompts), (None, None))
+
+
+@mock_streams('stdout')
+def test_pip_progressbar_at_4096_byte_boundary_error():
+    """
+    Test for unicode characters from the pip installation progress bar
+    causing a UnicodeDecodeError.
+    """
+    expect = '█' * 4096
+
+    class Mock(object):
+        def __init__(self):
+            three_bytes = u'█'.encode('utf-8')
+            # 4096 comes from OutputLooper.read_size being hard-coded to 4096
+            self.source = BytesIO(three_bytes * 4096)
+
+        def get_unicode_bytes(self, size):
+            return self.source.read(size)
+
+    ol = OutputLooper(Mock(), 'get_unicode_bytes', sys.stdout, None, None)
+
+    with settings(hide('everything')):
+        ol.loop()
+    eq_(expect, sys.stdout.getvalue())


### PR DESCRIPTION
Should resolve #5. 
Thanks @mathiasertl for the idea for the fix, tested to work for me at least.

Note: Built on top of #7 as that was useful in unit testing to check the test and fix worked on Python 2+3, so #7 should be reviewed first.

--

Additional testing notes:

```
# pip has a very useful --no-cache-dir option to force a re-download of a dependency
# which generates the progress bar with █ characters present
pip install --no-cache-dir
https://pip.pypa.io/en/stable/reference/pip_install/#caching
```

Large dependencies like [Django](https://github.com/django/django) tend to get more rendered progress bars, so I've had it fail usually between 14-32% of the way in, and never succeed without the connection getting closed (it does succeed in the background, so you can just rerun the fabric script).

For the final integration test I `pip install -e ~/Projects/fabric` and checked out the relevant branch then ran the relevant `pip install --no-cache-dir Django==1.8.7 # or 1.8.8 (to force a change and download/progress bar)` in a fabric script. Obviously results were as expected :beers: