### PR TITLE
Prefix octal literals with "0o" as specified in PEP3127

### DIFF
--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -297,7 +297,7 @@ def put(local_path=None, remote_path=None, use_sudo=False,
 
     Alternately, you may use the ``mode`` kwarg to specify an exact mode, in
     the same vein as ``os.chmod``, such as an exact octal number (``0o755``) or
-    a string representing one (``"0755"``).
+    a string representing one (``"0o755"``).
 
     `~fabric.operations.put` will honor `~fabric.context_managers.cd`, so
     relative values in ``remote_path`` will be prepended by the current remote

--- a/fabric/operations.py
+++ b/fabric/operations.py
@@ -296,7 +296,7 @@ def put(local_path=None, remote_path=None, use_sudo=False,
     scripts). To do this, specify ``mirror_local_mode=True``.
 
     Alternately, you may use the ``mode`` kwarg to specify an exact mode, in
-    the same vein as ``os.chmod``, such as an exact octal number (``0755``) or
+    the same vein as ``os.chmod``, such as an exact octal number (``0o755``) or
     a string representing one (``"0755"``).
 
     `~fabric.operations.put` will honor `~fabric.context_managers.cd`, so
@@ -315,7 +315,7 @@ def put(local_path=None, remote_path=None, use_sudo=False,
 
         put('bin/project.zip', '/tmp/project.zip')
         put('*.py', 'cgi-bin/')
-        put('index.html', 'index.html', mode=0755)
+        put('index.html', 'index.html', mode=0o755)
 
     .. note::
         If a file-like object such as StringIO has a ``name`` attribute, that

--- a/fabric/sftp.py
+++ b/fabric/sftp.py
@@ -276,11 +276,11 @@ class SFTP(object):
             # Cast to octal integer in case of string
             if isinstance(lmode, six.string_types):
                 lmode = int(lmode, 8)
-            lmode = lmode & int('07777', 8)
+            lmode = lmode & int('0o7777', 8)
             rmode = rattrs.st_mode
             # Only bitshift if we actually got an rmode
             if rmode is not None:
-                rmode = rmode & int('07777', 8)
+                rmode = rmode & int('0o7777', 8)
             if lmode != rmode:
                 if use_sudo:
                     # Temporarily nuke 'cwd' so sudo() doesn't "cd" its mv

--- a/integration/test_operations.py
+++ b/integration/test_operations.py
@@ -45,7 +45,7 @@ class TestOperations(Integration):
         assert_mode(self.filepath, "755")
 
     def test_int_put_mode_works_ok_too(self):
-        put(StringIO("#!/bin/bash\necho hi"), self.filepath, mode=0755)
+        put(StringIO("#!/bin/bash\necho hi"), self.filepath, mode=0o755)
         assert_mode(self.filepath, "755")
 
     def _chown(self, target):


### PR DESCRIPTION
This is optional in Python 2.6, and mandatory in Python 3.