### PR TITLE
Convert to list to avoid exception: "RuntimeError: dictionary changed si…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Generally this project aims to be a drop-in replacement for Fabric and will
 periodically merge any changes from the upstream project. Any differences are
 noted here:
 
-* The release installs as `Fabric3`. Despite it's name, this version is tested
+* The release installs as `Fabric3`. Despite its name, this version is tested
   with Python2.7 and Python 3.4+.
 * Versioning is based on upstream Fabric releases, with a `postX` appended. So
   version "1.12.0.post1" is equivalent to Fabrics own "1.12.0" release.

--- a/fabric/main.py
+++ b/fabric/main.py
@@ -197,7 +197,7 @@ def load_tasks_from_module(imported):
         imported_vars = [(name, imported_vars[name]) for name in \
                          imported_vars if name in imported_vars["__all__"]]
     else:
-        imported_vars = imported_vars.items()
+        imported_vars = list(imported_vars.items())
     # Return a two-tuple value.  First is the documentation, second is a
     # dictionary of callables only (and don't include Fab operations or
     # underscored callables)


### PR DESCRIPTION
…ze during iteration".

In Python 3 `dict.items()` does not return a list. This causes sometimes issues, when an imported module add some variables to its global vars. In my case it fails when importing module `celery.registry`. Why is it trying to find Fabric tasks there? I think Fabric should look for tasks in modules which are descendants of `fabfile` (or similar).