### PR TITLE
Fix DeprecationWarning on import for Python 3.6 (#34)

### DIFF
--- a/fabric/context_managers.py
+++ b/fabric/context_managers.py
@@ -326,7 +326,7 @@ def lcd(path):
 
 
 def _change_cwd(which, path):
-    path = path.replace(' ', '\ ')
+    path = path.replace(' ', r'\ ')
     if state.env.get(which) and not path.startswith('/') and not path.startswith('~'):
         new_cwd = state.env.get(which) + '/' + path
     else:

--- a/fabric/network.py
+++ b/fabric/network.py
@@ -31,7 +31,7 @@ Please make sure all dependencies are installed and importable.
 
 
 ipv6_regex = re.compile(
-    '^\[?(?P<host>[0-9A-Fa-f:]+(?:%[a-z]+\d+)?)\]?(:(?P<port>\d+))?$')
+    r'^\[?(?P<host>[0-9A-Fa-f:]+(?:%[a-z]+\d+)?)\]?(:(?P<port>\d+))?$')
 
 
 def direct_tcpip(client, host, port):


### PR DESCRIPTION
Fixes `DeprecationWarning` on Python 3.6 #34