### PR TITLE
utils/error(): fix crash on python3.4 when logging an error whithout …

### DIFF
--- a/fabric/utils.py
+++ b/fabric/utils.py
@@ -336,7 +336,7 @@ def error(message, func=None, exception=None, stdout=None, stderr=None):
     if func is None:
         func = fabric.state.env.warn_only and warn or abort
     # If exception printing is on, append a traceback to the message
-    if fabric.state.output.exceptions or fabric.state.output.debug:
+    if exception and (fabric.state.output.exceptions or fabric.state.output.debug):
         exception_message = format_exc()
         if exception_message:
             message += "\n\n" + exception_message

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -234,7 +234,7 @@ class TestErrorHandling(FabricTest):
         """
         error() includes traceback in message if exceptions logging is on
         """
-        error("error message", func=utils.abort, stdout=error)
+        error("error message", func=utils.abort, stdout=error, exception=True)
         assert_contains(self.dummy_string, sys.stdout.getvalue())
 
     @mock_streams('stdout')
@@ -247,7 +247,7 @@ class TestErrorHandling(FabricTest):
         """
         error() includes traceback in message if debug logging is on (backwardis compatibility)
         """
-        error("error message", func=utils.abort, stdout=error)
+        error("error message", func=utils.abort, stdout=error, exception=True)
         assert_contains(self.dummy_string, sys.stdout.getvalue())
 
     @mock_streams('stdout')


### PR DESCRIPTION
…an exception.

format_exc() breaks when there is no exception.
triggered when running fabric with "--show=debug"