### PR TITLE
Build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 exclude = tests/support,tests/Python26SocketServer.py,sites,fabric/api.py
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Supported Python 2 and 3 in the same wheel.

See https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels