### PR TITLE
Ensure underlying transport is closed on failed connection

### DIFF
--- a/fabric/network.py
+++ b/fabric/network.py
@@ -611,8 +611,10 @@ def connect(user, host, port, cache, seek_gateway=True):
         # Ensure that if we terminated without connecting and we were given an
         # explicit socket, close it out.
         finally:
-            if not connected and sock is not None:
-                sock.close()
+            if not connected:
+                client.close()
+                if sock is not None:
+                    sock.close()
 
 
 def _password_prompt(prompt, stream):


### PR DESCRIPTION
When various exceptions are raised fabric does not close off the underlying paramiko (TCP) session due to weakref/weakproxy connections, this may be related to https://github.com/paramiko/paramiko/issues/949

We have SSH servers that will deny new sessions for hosts after they reach a certain amount of sessions that have not passed authentication as it looks like a DoS attack.

This behaviour can be replicated using the following:
```
import gc
import paramiko
from fabric.api import run, env

env.host_string = "127.0.0.1"
env.user = 'username'
env.abort_on_prompts=True

def transport_waiting_for_auth(maybe_transport):
    if isinstance(maybe_transport, paramiko.Transport) and type(maybe_transport).__name__ not in  ['weakref', 'weakproxy']:
        transport = maybe_transport
        return transport.active and transport.initial_kex_done and not transport.is_authenticated()

def awaiting_auth():
    for obj in gc.get_objects():
        if transport_waiting_for_auth(obj):
            yield obj

def show_active():
    for transport in awaiting_auth():
        print(transport)

def password_setter():
    env.password = 'incorrect'
    yield
    yield
    yield
    yield
    env.password = 'correct'
    yield

for _ in password_setter():
    try:
        print("attempting connect {}:{}@{}".format(env.user, env.password, env.host_string))
        run('netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED')
    except SystemExit as e:
        print("SystemExit({})".format(e))
    finally:
        show_active()
        print("\n\n\n")
```
results in:
```
attempting connect cladam:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)
<paramiko.Transport at 0xdf7a8630 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>




attempting connect username:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)
<paramiko.Transport at 0xdf54cc18 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf7a8630 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>




attempting connect username:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)
<paramiko.Transport at 0xdf55e358 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf7a8630 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf54cc18 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>




attempting connect username:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)
<paramiko.Transport at 0xdf54cdd8 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf7a8630 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf54cc18 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf55e358 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>




attempting connect username:correct@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:22            127.0.0.1:51888         ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:51892         127.0.0.1:22            ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:51888         127.0.0.1:22            ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:51890         127.0.0.1:22            ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:22            127.0.0.1:51886         ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:22            127.0.0.1:51884         ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:22            127.0.0.1:51890         ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:51884         127.0.0.1:22            ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:51886         127.0.0.1:22            ESTABLISHED
[127.0.0.1] out: tcp        0    112 127.0.0.1:22            127.0.0.1:51892         ESTABLISHED
[127.0.0.1] out:

<paramiko.Transport at 0xdf7a8630 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf54cc18 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf55e358 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
<paramiko.Transport at 0xdf54cdd8 (cipher aes128-ctr, 128 bits) (connected; awaiting auth)>
```

It can also be observed using `tcpdump -i lo port 22` where all sessions only send FIN TCP when the intepreter exits.

There is already a `finally` clause which closes out a provided socket, but this should also close out the `client` too.

With the pull request the same script behavour is:
```
attempting connect cladam:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)




attempting connect username:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)




attempting connect username:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)




attempting connect username:incorrect@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED

Fatal error: Needed to prompt for a connection or sudo password (host: 127.0.0.1), but abort-on-prompts was set to True

Aborting.
SystemExit(1)




attempting connect username:correct@127.0.0.1
[127.0.0.1] run: netstat -an | grep 127.0.0.1:22 | grep ESTABLISHED
[127.0.0.1] out: tcp        0    112 127.0.0.1:22            127.0.0.1:51918         ESTABLISHED
[127.0.0.1] out: tcp        0      0 127.0.0.1:51918         127.0.0.1:22            ESTABLISHED
[127.0.0.1] out:
```