### PR TITLE
adding python 3.10 and greater compatability

### DIFF
--- a/fabric/main.py
+++ b/fabric/main.py
@@ -9,7 +9,10 @@ The other callables defined in this module are internal only. Anything useful
 to individuals leveraging Fabric as a library, should be kept elsewhere.
 """
 import getpass
-from collections import Mapping
+try:
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
 import inspect
 from optparse import OptionParser
 import os

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,8 @@
 import copy
-from collections import Mapping
+try:
+    from collections import Mapping
+except ImportError:
+    from collections.abc import Mapping
 from functools import partial
 import six
 import os.path


### PR DESCRIPTION
Our team uses this tool heavily and thank you for all the work you've put into maintaining this in the past. While this repository is relatively dead (as what it set out to do is complete), we noticed that using it with Python 3.10 broke the tool. Upon closer inspection, the reason was this: 

> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/3/library/collections.html#module-collections) module. (Contributed by Victor Stinner in [bpo-37324](https://bugs.python.org/issue?@action=redirect&bpo=37324).)

(Pulled from [Python 3.10 Release Notes](https://docs.python.org/3/whatsnew/3.10.html))

We've tested the tool with this PR and it continues to work well on Python 3.10. We would really appreciate merging this to main and cutting a new release as it would allow us to not have to rely on an internal fork (as well as help any other folks that are using this tool still).