### PR TITLE
Fix fabric3 for Python 3.10+

### DIFF
--- a/fabric/main.py
+++ b/fabric/main.py
@@ -9,7 +9,10 @@ The other callables defined in this module are internal only. Anything useful
 to individuals leveraging Fabric as a library, should be kept elsewhere.
 """
 import getpass
-from collections import Mapping
+try:
+    from collections import Mapping
+except ImportError: #Python 3.10+ moved mapping to collections.abc
+    from collections.abc import Mapping
 import inspect
 from optparse import OptionParser
 import os


### PR DESCRIPTION
In Python 3.10+ the Mapping moved to collections.abc, this proposed change made my fabric3 install work